### PR TITLE
DBの設定

### DIFF
--- a/src/main/java/oit/is/z1928/kaizi/janken/security/JankenAuthConfiguration.java
+++ b/src/main/java/oit/is/z1928/kaizi/janken/security/JankenAuthConfiguration.java
@@ -30,7 +30,12 @@ public class JankenAuthConfiguration {
             .logoutSuccessUrl("/")) // ログアウト後に / にリダイレクト
         .authorizeHttpRequests(authz -> authz
             .requestMatchers(AntPathRequestMatcher.antMatcher("/janken/**")).authenticated()
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/**")).permitAll()); // それ以外は全員アクセス可能
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/**")).permitAll())
+        .csrf(csrf -> csrf
+            .ignoringRequestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/*")))
+        .headers(headers -> headers
+            .frameOptions(frameOptions -> frameOptions
+                .sameOrigin()));
     return http.build();
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+server.port=8080
+spring.sql.init.encoding=UTF-8
+spring.datasource.url=jdbc:h2:mem:janken
+
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled:true
+
+logging.level.root=INFO


### PR DESCRIPTION
application.propertiesにデータベース関連の設定を実施
・server.portは8080とする(server.port=8080)
・spring.datasource.urlはjdbc:h2:mem:jankenに変更
・h2-consoleにアクセスできるようにspring.h2.console.enabled:trueを追加
JankenAuthConfiguration.javaにh2-consoleにアクセスするための設定を追記